### PR TITLE
Dropping charms.templating.jinja2 (and Tempita) for focal and jammy i…

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,16 @@
+name: Run tests with Tox
+
+on: [pull_request]
+
+jobs:
+  call-inclusive-naming-check:
+    name: Inclusive naming
+    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    with:
+      fail-on-error: "true"
+
+  lint-unit:
+    name: Lint Unit
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    needs:
+      - call-inclusive-naming-check 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-    - "3.5"
-install:
-    - pip install tox-travis
-script:
-    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
 skipsdist = True
-envlist = lint,py3
+envlist = lint,unit
 
 [testenv]
 basepython = python3
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/lib
+
+[testenv:unit]
 deps =
     pytest
     flake8
@@ -13,5 +15,6 @@ deps =
 commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
-envdir = {toxworkdir}/py3
+deps =
+    flake8
 commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,12 @@
 charms.docker>=0.0.1,<=2.0.0
 vcversioner>=2.0.0,<=3.0.0
-charms.templating.jinja2>=0.0.1,<=2.0.0
 requests>=2.0.0,<3.0.0
+
+# idna>=2.28.1 and beyond (needed by requests)
+# requires flit-core for building its wheel.
+# 
+# flit-core can run on python3.6, but requires pip 
+# be upgraded to at least 20.0.2 (same as on focal)
+#
+flit-core<4
+pip==20.0.2  # necessary for bionic


### PR DESCRIPTION
…nstallations (#144)

* Dropping charms.templating.jinja2 which will in turn drop Tempita for focal and jammy installations

* start github workflows

* adjust tox to run unit and lint