### PR TITLE
[LP#2110229] Fix docker registry charm no proxy expansion (KU-3440)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -1,4 +1,3 @@
-import ipaddress
 import json
 
 from subprocess import check_output

--- a/lib/charms/layer/docker.py
+++ b/lib/charms/layer/docker.py
@@ -62,19 +62,8 @@ def render_configuration_template(service=False):
     modified_config = dict(config())
     parsed_hosts = ""
     if environment_config is not None:
-        hosts = []
-        for address in environment_config.get("NO_PROXY", "").split(","):
-            address = address.strip()
-            try:
-                net = ipaddress.ip_network(address)
-                ip_addresses = [str(ip) for ip in net.hosts()]
-                if ip_addresses == []:
-                    hosts.append(address)
-                else:
-                    hosts += ip_addresses
-            except ValueError:
-                hosts.append(address)
-        parsed_hosts = ",".join(hosts)
+        hosts = environment_config.get("NO_PROXY", "").split(",")
+        parsed_hosts = ",".join(host.strip() for host in hosts)
         environment_config.update({"NO_PROXY": parsed_hosts, "no_proxy": parsed_hosts})
         for key in ["http_proxy", "https_proxy", "no_proxy"]:
             if not modified_config.get(key):

--- a/tests/test_lib_docker.py
+++ b/tests/test_lib_docker.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from charms.layer.docker import write_daemon_json
 from charms.layer.docker import set_daemon_json
 from charms.layer.docker import delete_daemon_json
+from charms.layer.docker import render_configuration_template
 
 
 @patch("charmhelpers.core.unitdata.kv")
@@ -71,3 +72,38 @@ def test_delete_daemon_json(kv):
         kv.return_value.get.return_value = daemon_opts_additions
         assert delete_daemon_json("foo") is True
         kv().set.assert_called_once_with("daemon-opts-additions", {})
+
+
+@patch("charms.layer.docker.write_daemon_json")
+@patch("charms.layer.docker.render")
+@patch("charms.layer.docker.determine_apt_source")
+@patch("charms.layer.docker.hookenv")
+@patch("charms.layer.docker.DockerOpts")
+def test_render_configuration_template_no_proxy(
+    mock_docker_opts, mock_hookenv, mock_determine_apt, mock_render, mock_write_daemon
+):
+    """Test if the render_configuration_template produced the right dict."""
+    mock_determine_apt.return_value = "apt"
+    mock_docker_opts.return_value.to_s.return_value = ""
+    env_proxy = {
+        "http_proxy": "",
+        "https_proxy": "",
+        "NO_PROXY": "localhost, 10.0.0.0/30",
+    }
+
+    charm_config = {
+        "docker-opts": "",
+        "http_proxy": "",
+        "https_proxy": "",
+        "no_proxy": "",
+    }
+    mock_hookenv.config.side_effect = lambda *args: (
+        charm_config[args[0]] if args else charm_config
+    )
+    mock_hookenv.config.return_value = charm_config
+    mock_hookenv.env_proxy_settings.return_value = env_proxy
+
+    render_configuration_template(service=True)
+
+    config = mock_render.call_args_list[1][0][2]
+    assert config["no_proxy"] == "localhost,10.0.0.0/30"

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     ruff
     black
 commands = 
-    ruff --fix {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+    ruff check --fix {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
     black {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
 
 
@@ -27,6 +27,6 @@ deps =
     ruff
     black
 commands = 
-    ruff {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+    ruff check {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
     black --check {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
 


### PR DESCRIPTION
### BUG
[LP#2110229](https://bugs.launchpad.net/layer-docker-registry/+bug/2110229)
The original code expands the  any network present in the NO_PROXY variable using CIDR notation to a list of hosts. And this would take up all the memory if user added an IPv6 network to NO_PROXY.

### FIX
The code was written this way because Docker didn't support CIDR in NO_PROXY, but now docker supports it. So simply removing the line that extracts all addresses fixes the problem

### TESTS
Verified that the Docker daemon is able to parse CIDR notation within the NO_PROXY environment variable across Ubuntu@20.04, Ubuntu@22.04, and Ubuntu@24.04, covering docker.io versions 19 through 28 locally.

### Additional notes
Go started to support CIDR in no-proxy starting version 1.11: [Go release note: 1.11](https://go.dev/doc/go1.11)
And Docker upgraded its go version to above 1.11 starting version 19.03: [Docker release note: 19.03](https://docs.docker.com/engine/release-notes/19.03/)
So I think it's safe to assume the fix should work for any Docker version later than 19.03.